### PR TITLE
Fix CVE-2025-48882

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "ext-zip": "*",
         "ext-json": "*",
         "ext-xml": "*",
-        "phpoffice/math": "0.3"
+        "phpoffice/math": "^0.3"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "ext-zip": "*",
         "ext-json": "*",
         "ext-xml": "*",
-        "phpoffice/math": "^0.2"
+        "phpoffice/math": "0.3"
     },
     "require-dev": {
         "ext-libxml": "*",

--- a/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
+++ b/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
@@ -125,6 +125,7 @@ class PasswordEncoder
             throw new Exception('Failed to convert password to UCS-2LE');
         }
 
+
         $byteChars = [];
         for ($i = 0; $i < mb_strlen($password); ++$i) {
             $byteChars[$i] = ord(substr($passUtf8, $i * 2, 1));

--- a/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
+++ b/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
@@ -125,7 +125,6 @@ class PasswordEncoder
             throw new Exception('Failed to convert password to UCS-2LE');
         }
 
-
         $byteChars = [];
         for ($i = 0; $i < mb_strlen($password); ++$i) {
             $byteChars[$i] = ord(substr($passUtf8, $i * 2, 1));

--- a/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
+++ b/src/PhpWord/Shared/Microsoft/PasswordEncoder.php
@@ -18,6 +18,8 @@
 
 namespace PhpOffice\PhpWord\Shared\Microsoft;
 
+use PhpOffice\PhpWord\Exception\Exception;
+
 /**
  * Password encoder for microsoft office applications.
  */
@@ -119,8 +121,11 @@ class PasswordEncoder
         //   Get the single-byte values by iterating through the Unicode characters of the truncated password.
         //   For each character, if the low byte is not equal to 0, take it. Otherwise, take the high byte.
         $passUtf8 = mb_convert_encoding($password, 'UCS-2LE', 'UTF-8');
-        $byteChars = [];
+        if (!is_string($passUtf8)) {
+            throw new Exception('Failed to convert password to UCS-2LE');
+        }
 
+        $byteChars = [];
         for ($i = 0; $i < mb_strlen($password); ++$i) {
             $byteChars[$i] = ord(substr($passUtf8, $i * 2, 1));
 

--- a/src/PhpWord/Shared/Text.php
+++ b/src/PhpWord/Shared/Text.php
@@ -144,7 +144,6 @@ class Text
      * @param null|string $value
      *
      * @return ?string
-     * @throws Exception
      */
     public static function toUTF8($value = '')
     {

--- a/src/PhpWord/Shared/Text.php
+++ b/src/PhpWord/Shared/Text.php
@@ -18,6 +18,8 @@
 
 namespace PhpOffice\PhpWord\Shared;
 
+use PhpOffice\PhpWord\Exception\Exception;
+
 /**
  * Text.
  */
@@ -142,12 +144,16 @@ class Text
      * @param null|string $value
      *
      * @return ?string
+     * @throws Exception
      */
     public static function toUTF8($value = '')
     {
         if (null !== $value && !self::isUTF8($value)) {
             // PHP8.2 : utf8_encode is deprecated, but mb_convert_encoding always usable
             $value = (function_exists('mb_convert_encoding')) ? mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1') : utf8_encode($value);
+            if ($value === false) {
+                throw new Exception('Unable to convert text to UTF-8');
+            }
         }
 
         return $value;

--- a/tests/PhpWordTests/Writer/Word2007/Element/TOCTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Element/TOCTest.php
@@ -63,11 +63,16 @@ class TOCTest extends \PHPUnit\Framework\TestCase
         $section = $phpWord->addSection();
         $section->addTOC();
 
+        $staticHtml = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. 
+            Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. 
+            Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi.</p>
+            <p>Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat. 
+            Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim.</p>';
+
         //more than one title and random text for create more than one page
         for ($i = 1; $i <= 10; ++$i) {
             $section->addTitle('Title ' . $i, 1);
-            $content = file_get_contents('https://loripsum.net/api/10/long');
-            \PhpOffice\PhpWord\Shared\Html::addHtml($section, $content ? $content : '', false, false);
+            \PhpOffice\PhpWord\Shared\Html::addHtml($section, $staticHtml, false, false);
             $section->addPageBreak();
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,7 +54,9 @@ function phpunit10ErrorHandler(int $errno, string $errstr, string $filename, int
 
 function utf8decode(string $value, string $toEncoding = 'ISO-8859-1'): string
 {
-    return function_exists('mb_convert_encoding') ? mb_convert_encoding($value, $toEncoding, 'UTF-8') : utf8_decode($value);
+    $result = function_exists('mb_convert_encoding') ? mb_convert_encoding($value, $toEncoding, 'UTF-8') : utf8_decode($value);
+
+    return $result === false ? '' : $result;
 }
 
 if (!method_exists(PHPUnit\Framework\TestCase::class, 'setOutputCallback')) {


### PR DESCRIPTION
### Description

- Update `phpoffice/math` to the latest version with fix for `CVE-2025-48882`.
- Code fixes so that CI is green

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
