### PR TITLE
Fix parsing of unclosed img tags in HTML input

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -91,7 +91,7 @@ class Html
         }
         $dom = new DOMDocument();
         $dom->preserveWhiteSpace = $preserveWhiteSpace;
-        $dom->loadXML($html);
+        $dom->loadHTML($html);
         static::$xpath = new DOMXPath($dom);
         $node = $dom->getElementsByTagName('body');
 

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -96,12 +96,11 @@ class Html
             $validXml = self::convertHtmlToXml($html);
         }
 
-        $xmlDom = new DOMDocument();
-        $xmlDom->preserveWhiteSpace = $preserveWhiteSpace;
-        $xmlDom->loadXML($validXml);
-
-        static::$xpath = new DOMXPath($xmlDom);
-        $node = $xmlDom->getElementsByTagName('body');
+        $dom = new DOMDocument();
+        $dom->preserveWhiteSpace = $preserveWhiteSpace;
+        $dom->loadXML($validXml);
+        static::$xpath = new DOMXPath($dom);
+        $node = $dom->getElementsByTagName('body');
 
         static::parseNode($node->item(0), $element);
         if (\PHP_VERSION_ID < 80000) {
@@ -1322,6 +1321,11 @@ class Html
         return trim($rgb, '# ');
     }
 
+    /**
+     * @param string $xml
+     *
+     * @return bool
+     */
     private static function isRubyCode(string $xml): bool
     {
         $pattern = '/<ruby\b([^>]*)>(.*?)<\/ruby>/is';
@@ -1330,9 +1334,10 @@ class Html
     }
 
     /**
-     * Converts HTML to well-formed XML
+     * Converts HTML to well-formed XML.
      *
      * @param string $html The HTML content to convert
+     *
      * @return string The well-formed XML
      * @throws Exception If conversion fails
      */

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -1321,11 +1321,6 @@ class Html
         return trim($rgb, '# ');
     }
 
-    /**
-     * @param string $xml
-     *
-     * @return bool
-     */
     private static function isRubyCode(string $xml): bool
     {
         $pattern = '/<ruby\b([^>]*)>(.*?)<\/ruby>/is';
@@ -1339,7 +1334,6 @@ class Html
      * @param string $html The HTML content to convert
      *
      * @return string The well-formed XML
-     * @throws Exception If conversion fails
      */
     protected static function convertHtmlToXml(string $html): string
     {

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -90,12 +90,10 @@ class Html
             $orignalLibEntityLoader = libxml_disable_entity_loader(true);
         }
 
-        $htmlDom = new DOMDocument();
-        $htmlDom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-
-        $validXml = $htmlDom->saveXML($htmlDom->documentElement);
-        if (false === $validXml) {
-            throw new Exception('Could not convert HTML to valid XML');
+        if (self::isRubyCode($html)) {
+            $validXml = $html;
+        } else {
+            $validXml = self::convertHtmlToXml($html);
         }
 
         $xmlDom = new DOMDocument();
@@ -1322,6 +1320,33 @@ class Html
         }
 
         return trim($rgb, '# ');
+    }
+
+    private static function isRubyCode(string $xml): bool
+    {
+        $pattern = '/<ruby\b([^>]*)>(.*?)<\/ruby>/is';
+
+        return preg_match($pattern, $xml, $matches) === 1;
+    }
+
+    /**
+     * Converts HTML to well-formed XML
+     *
+     * @param string $html The HTML content to convert
+     * @return string The well-formed XML
+     * @throws Exception If conversion fails
+     */
+    protected static function convertHtmlToXml(string $html): string
+    {
+        $htmlDom = new DOMDocument();
+        $htmlDom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+        $validXml = $htmlDom->saveXML($htmlDom->documentElement);
+        if (false === $validXml) {
+            throw new Exception('Could not convert HTML to valid XML');
+        }
+
+        return $validXml;
     }
 
     /**

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -89,11 +89,21 @@ class Html
         if (\PHP_VERSION_ID < 80000) {
             $orignalLibEntityLoader = libxml_disable_entity_loader(true);
         }
-        $dom = new DOMDocument();
-        $dom->preserveWhiteSpace = $preserveWhiteSpace;
-        $dom->loadHTML($html);
-        static::$xpath = new DOMXPath($dom);
-        $node = $dom->getElementsByTagName('body');
+
+        $htmlDom = new DOMDocument();
+        $htmlDom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+        $validXml = $htmlDom->saveXML($htmlDom->documentElement);
+        if (false === $validXml) {
+            throw new Exception('Could not convert HTML to valid XML');
+        }
+
+        $xmlDom = new DOMDocument();
+        $xmlDom->preserveWhiteSpace = $preserveWhiteSpace;
+        $xmlDom->loadXML($validXml);
+
+        static::$xpath = new DOMXPath($xmlDom);
+        $node = $xmlDom->getElementsByTagName('body');
 
         static::parseNode($node->item(0), $element);
         if (\PHP_VERSION_ID < 80000) {

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -1036,6 +1036,24 @@ HTML;
     }
 
     /**
+     * Test parsing of unclosed img tag.
+     */
+    public function testParseUnclosedImageTag(): void
+    {
+        $src = self::getRemoteImageUrl();
+
+        $phpWord = new PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="' . $src . '"></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        self::assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+    }
+
+    /**
      * Test parsing embedded image.
      */
     public function testParseEmbeddedImage(): void


### PR DESCRIPTION
### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.4.0.md)
